### PR TITLE
Upgrade packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,84 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.10 as base
+
+FROM base as builder
+
+ENV LANG=C.UTF-8
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ghostscript \
         gosu \
+        build-essential autoconf automake libtool \
+        libleptonica-dev \
+        zlib1g-dev \
+        ca-certificates \
+        curl \
+        git \
         python3-venv \
         python3-pip \
         qpdf \
+        pngquant \
         tesseract-ocr \
         tesseract-ocr-eng \
         tesseract-ocr-osd \
         unpaper \
     && rm -rf /var/lib/apt/lists/*
 
-ENV LANG=C.UTF-8
+# Get the latest pip (Ubuntu version doesn't support manylinux2010)
+RUN \
+  curl https://bootstrap.pypa.io/get-pip.py | python3
 
-RUN python3 -m venv --system-site-packages /appenv
+# Compile and install jbig2
+# Needs libleptonica-dev, zlib1g-dev
+RUN \
+  mkdir jbig2 \
+  && curl -L https://github.com/agl/jbig2enc/archive/ea6a40a.tar.gz | \
+  tar xz -C jbig2 --strip-components=1 \
+  && cd jbig2 \
+  && ./autogen.sh && ./configure && make && make install \
+  && cd .. \
+  && rm -rf jbig2
 
-RUN . /appenv/bin/activate; \
-    pip install --upgrade pip
 
-# Pull in ocrmypdf via requirements.txt and install pinned version
 COPY src/requirements.txt /app/
-
+RUN python3 -m venv --system-site-packages /appenv
 RUN . /appenv/bin/activate; \
     pip install -r /app/requirements.txt
 
+
+### Begin Runtime Image
+FROM base
+
+ENV LANG=C.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ghostscript \
+  img2pdf \
+  liblept5 \
+  libsm6 libxext6 libxrender-dev \
+  zlib1g \
+  pngquant \
+  python3 \
+  python3-venv \
+  qpdf \
+  gosu \
+  tesseract-ocr \
+  tesseract-ocr-deu \
+  tesseract-ocr-eng \
+  unpaper
+
+WORKDIR /app
+
+COPY --from=builder /usr/local/lib/ /usr/local/lib/
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /appenv /appenv
+
+RUN python3 -m venv --system-site-packages /appenv
+
+RUN . /appenv/bin/activate;
+
 COPY src/ /app/
+
 
 # Create restricted privilege user docker:docker to drop privileges
 # to later. We retain root for the entrypoint in order to install
@@ -40,4 +92,3 @@ RUN groupadd -g 1000 docker && \
 VOLUME ["/config", "/input", "/output", "/ocrtemp", "/archive"]
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,29 @@
-FROM ubuntu:20.10 as base
+FROM ubuntu:20.04 as base
 
 FROM base as builder
+
+ENV LANG=C.UTF-8
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        ca-certificates \
+        curl \
+        libleptonica-dev \
+        libtool \
+        zlib1g-dev \
+    && mkdir src \
+    && cd src \
+    && curl -L https://github.com/agl/jbig2enc/archive/ea6a40a2cbf05efb00f3418f2d0ad71232565beb.tar.gz --output jbig2.tgz \
+    && tar xzf jbig2.tgz --strip-components=1 \
+    && ./autogen.sh \
+    && ./configure \
+    && make \
+    && make install
+
+FROM base
 
 ENV LANG=C.UTF-8
 
@@ -8,77 +31,32 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ghostscript \
         gosu \
-        build-essential autoconf automake libtool \
-        libleptonica-dev \
-        zlib1g-dev \
-        ca-certificates \
-        curl \
-        git \
+        liblept5 \
+        pngquant \
         python3-venv \
         python3-pip \
         qpdf \
-        pngquant \
         tesseract-ocr \
         tesseract-ocr-eng \
         tesseract-ocr-osd \
         unpaper \
     && rm -rf /var/lib/apt/lists/*
 
-# Get the latest pip (Ubuntu version doesn't support manylinux2010)
-RUN \
-  curl https://bootstrap.pypa.io/get-pip.py | python3
+RUN python3 -m venv --system-site-packages /appenv \
+    && . /appenv/bin/activate \
+    && pip install --upgrade pip
 
-# Compile and install jbig2
-# Needs libleptonica-dev, zlib1g-dev
-RUN \
-  mkdir jbig2 \
-  && curl -L https://github.com/agl/jbig2enc/archive/ea6a40a.tar.gz | \
-  tar xz -C jbig2 --strip-components=1 \
-  && cd jbig2 \
-  && ./autogen.sh && ./configure && make && make install \
-  && cd .. \
-  && rm -rf jbig2
+# Copy jbig2 from builder image
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /usr/local/lib/ /usr/local/lib/
 
-
+# Pull in ocrmypdf via requirements.txt and install pinned version
 COPY src/requirements.txt /app/
-RUN python3 -m venv --system-site-packages /appenv
+
 RUN . /appenv/bin/activate; \
     pip install -r /app/requirements.txt
 
-
-### Begin Runtime Image
-FROM base
-
-ENV LANG=C.UTF-8
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ghostscript \
-  img2pdf \
-  liblept5 \
-  libsm6 libxext6 libxrender-dev \
-  zlib1g \
-  pngquant \
-  python3 \
-  python3-venv \
-  qpdf \
-  gosu \
-  tesseract-ocr \
-  tesseract-ocr-deu \
-  tesseract-ocr-eng \
-  unpaper
-
-WORKDIR /app
-
-COPY --from=builder /usr/local/lib/ /usr/local/lib/
-COPY --from=builder /usr/local/bin/ /usr/local/bin/
-COPY --from=builder /appenv /appenv
-
-RUN python3 -m venv --system-site-packages /appenv
-
-RUN . /appenv/bin/activate;
-
 COPY src/ /app/
-
 
 # Create restricted privilege user docker:docker to drop privileges
 # to later. We retain root for the entrypoint in order to install
@@ -92,3 +70,4 @@ RUN groupadd -g 1000 docker && \
 VOLUME ["/config", "/input", "/output", "/ocrtemp", "/archive"]
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
+

--- a/src/ocrmypdf-auto.py
+++ b/src/ocrmypdf-auto.py
@@ -170,7 +170,7 @@ class OcrTask(object):
 
     def process(self, skip_delay=False):
         """OCR processing task"""
-        self.logger.warn('Processing: %s -> %s', self.input_path, self.output_path)
+        self.logger.warning('Processing: %s -> %s', self.input_path, self.output_path)
         start_ts = datetime.now()
 
         # Coalescing sleep as long as file is still being modified
@@ -211,7 +211,7 @@ class OcrTask(object):
             self.logger.info('OCRmyPDF failed with rc %d stdout [%s] and stderr [%s]', rc, stdout, stderr)
 
         runtime = datetime.now() - start_ts
-        self.logger.warn('Processing complete in %f seconds with status %d: %s', round(runtime.total_seconds(), 2), rc, self.input_path)
+        self.logger.warning('Processing complete in %f seconds with status %d: %s', round(runtime.total_seconds(), 2), rc, self.input_path)
         test_log('OCR_PROCESS_RESULT\0%s\0%s\0%d\0%f', self.input_path, self.output_path, rc, round(runtime.total_seconds(), 2))
 
         # Check for modification during sleep
@@ -231,12 +231,12 @@ class OcrTask(object):
             # 2. Output file's modification time MUST be more recent than the input file's
             #    modification time captured at job start
             if output_mtime < input_mtime_before:
-                self.logger.warn('Not %s input file. Output file %s was modified earlier [%s] than input file %s was modified [%s]',
+                self.logger.warning('Not %s input file. Output file %s was modified earlier [%s] than input file %s was modified [%s]',
                                  'deleting' if self.success_action == OcrTask.ON_SUCCESS_DELETE_INPUT else 'archiving',
                                  self.output_path, output_mtime,
                                  self.input_path, input_mtime_before)
             elif input_mtime_after != input_mtime_before:
-                self.logger.warn('Not %s input file. Input file %s modification time after OCR task [%s] is not equal to before task [%s]',
+                self.logger.warning('Not %s input file. Input file %s modification time after OCR task [%s] is not equal to before task [%s]',
                                  'deleting' if self.success_action == OcrTask.ON_SUCCESS_DELETE_INPUT else 'archiving',
                                  self.input_path,
                                  input_mtime_after, input_mtime_before)
@@ -252,7 +252,7 @@ class OcrTask(object):
                     self.logger.debug('Archived input file after successful OCR: %s -> %s', self.input_path, self.archive_path)
 
         # Notify if notification url is set and run was successful
-        if rc == 0  and '' is not self.notify_url:
+        if rc == 0  and '' != self.notify_url:
             # Build json
             output_data = {
                 "pdf": self.output_path
@@ -278,7 +278,7 @@ class AutoOcrWatchdogHandler(PatternMatchingEventHandler):
     Matches files to process through OCR and kicks off processing
     """
 
-    MATCH_PATTERNS = ['*.pdf']
+    MATCH_PATTERNS = ['*.pdf', '*.jpg']
 
     def __init__(self, file_touched_callback, file_deleted_callback):
         super(AutoOcrWatchdogHandler, self).__init__(patterns = AutoOcrWatchdogHandler.MATCH_PATTERNS, ignore_directories=True)
@@ -367,10 +367,10 @@ class AutoOcrScheduler(object):
             self.observer = Observer()
             self.observer.schedule(watchdog_handler, self.input_dir, recursive=True)
             self.observer.start()
-            self.logger.warn('Watching %s', self.input_dir)
+            self.logger.warning('Watching %s', self.input_dir)
         else:
             self.observer = None
-            self.logger.warn('Not watching %s', self.input_dir)
+            self.logger.warning('Not watching %s', self.input_dir)
 
         # Process existing files in input directory, if requested
         if process_existing_files:
@@ -549,8 +549,8 @@ if __name__ == "__main__":
         if single_shot_mode:
             # Wait for all initial (process existing) tasks to complete
             scheduler.wait_for_idle()
-            logger.warn('No remaining OCR tasks, and scheduler not started. Shutting down...')
+            logger.warning('No remaining OCR tasks, and scheduler not started. Shutting down...')
         else:
             # Wait in the main thread to be terminated
             signum = docker_monitor.wait_for_exit()
-            logger.warn('Signal %d (%s) Received. Shutting down...', signum, DockerSignalMonitor.SIGNUMS_TO_NAMES[signum])
+            logger.warning('Signal %d (%s) Received. Shutting down...', signum, DockerSignalMonitor.SIGNUMS_TO_NAMES[signum])

--- a/src/ocrmypdf-auto.py
+++ b/src/ocrmypdf-auto.py
@@ -252,7 +252,7 @@ class OcrTask(object):
                     self.logger.debug('Archived input file after successful OCR: %s -> %s', self.input_path, self.archive_path)
 
         # Notify if notification url is set and run was successful
-        if rc == 0  and '' != self.notify_url:
+        if rc == 0  and self.notify_url:
             # Build json
             output_data = {
                 "pdf": self.output_path

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-plumbum==1.6.9
+plumbum~=1.6.9
 ocrmypdf==11.3.3
-watchdog==0.10.3
+watchdog~=0.10.3
 requests~=2.25.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-plumbum==1.6.6
-ocrmypdf[fitz]==6.2.0
-watchdog==0.8.3
-requests~=2.20.0
+plumbum==1.6.9
+ocrmypdf==11.3.3
+watchdog==0.10.3
+requests~=2.25.0


### PR DESCRIPTION
Upgrade packages
Upgrade base image
Restructure Dockerfile
Fix python warnings

I adapted the structure of the Dockerfile to be closer to the one from ocrmypdf-auto.
Can probably be optimized more.

You can merge it or just use it as inspiration and take parts that you deem fit.  

Overall, I think that it would be easier to just use the docker image from ocrmypdf directly as base. This saves a lot of effort and makes sure that ocrmypdf has all of its dependencies. Aside from updating the base from time to time no further effort should be necessary to get ocrmypdf running in newer versions.