### PR TITLE
Update CI/CD and dev flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,18 @@ version: 2.1
 jobs:
   build_test:
     docker:
-      - image: circleci/python:3.7.2
+      - image: cimg/python:3.8
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
 
     steps:
       - checkout
       - setup_remote_docker
+      - run:
+          name: Login to Docker within Executor
+          command: |
+            echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USER --password-stdin
       - run:
           name: Build Docker image
           command: docker build -t ocrmypdf-auto .
@@ -37,7 +44,10 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.7.2
+      - image: cimg/python:3.8
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
     steps:
       - setup_remote_docker
       - attach_workspace:
@@ -47,11 +57,11 @@ jobs:
           command: |
             docker load --input build-output/image.tar
       - run:
-          name: "Push to quay.io as :beta"
+          name: "Push to Docker Hub as :beta"
           command: |
-            echo $QUAYIO_PASSWORD | docker login -u $QUAYIO_USER --password-stdin quay.io
-            docker tag ocrmypdf-auto quay.io/cmccambridge/ocrmypdf-auto:beta
-            docker push quay.io/cmccambridge/ocrmypdf-auto:beta
+            echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USER --password-stdin
+            docker tag ocrmypdf-auto cmccambridge/ocrmypdf-auto:beta
+            docker push cmccambridge/ocrmypdf-auto:beta
 
 workflows:
   build_test_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,10 @@ jobs:
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USER --password-stdin
       - run:
           name: Build Docker image
-          command: docker build -t ocrmypdf-auto .
+          command: make ocrmypdf-auto
       - run:
           name: Test Docker image
-          command: |
-            python3 -m venv .venv
-            source .venv/bin/activate
-            pip install -r tests/requirements.txt
-            mkdir -p test-results/docker
-            pytest --junit-xml=test-results/docker/results.xml tests/
+          command: make test
       - store_test_results:
           path: test-results
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Makefile marker
+ocrmypdf-auto
+
 *~
 *.swp
 .vs
@@ -8,6 +11,7 @@ __pycache__/
 .pytest_cache
 
 /.venv
+/.test_venv
 /env
 /testarchive
 /testconfig

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+MKDIR_P := mkdir -p
+
+.PHONY: all clean images test release
+
+all: images test
+
+clean:
+	-rm -f ocrmypdf-auto
+	-docker image rm ocrmypdf-auto
+
+images: ocrmypdf-auto
+
+ocrmypdf-auto: Dockerfile src/*
+	docker build -t ocrmypdf-auto . && touch ocrmypdf-auto
+
+test_venv: .test_venv/touch
+
+.test_venv/touch: tests/requirements.txt
+	test -d .test_venv || python3 -m venv .test_venv
+	. .test_venv/bin/activate; pip install -Ur tests/requirements.txt
+	touch .test_venv/touch
+
+test: ocrmypdf-auto test_venv tests/docker/*.py
+	$(MKDIR_P) test-results/docker
+	. .test_venv/bin/activate; pytest --junit-xml=test-results/docker/results.xml tests/
+
+release:
+ifndef RELEASE_TAG
+	$(error Missing RELEASE_TAG)
+endif
+	docker pull cmccambridge/ocrmypdf-auto:beta
+	docker tag cmccambridge/ocrmypdf-auto:beta cmccambridge/ocrmypdf-auto:$(RELEASE_TAG)
+	docker push cmccambridge/ocrmypdf-auto:$(RELEASE_TAG)


### PR DESCRIPTION
* Circle CI configuration needs updates to do authenticated Docker Hub pulls
* Moving the CI/CD configuration from quay.io to Docker Hub, which is where Unraid templates pull from (Will sort out mirroring to quay.io when functional changes are actually ready.)
* Add a `Makefile` for consistent local build & test vs CI build & test.